### PR TITLE
feat(wizard): add model selection screen with curated lists

### DIFF
--- a/feroxmute-cli/src/wizard/screens.rs
+++ b/feroxmute-cli/src/wizard/screens.rs
@@ -251,9 +251,8 @@ pub fn render_model_selection(frame: &mut Frame, state: &WizardState) {
         input.render(frame, input_area);
     } else {
         // List selection mode — build labels with "Custom..." appended
-        let mut labels: Vec<String> = models.iter().map(|m| m.1.to_string()).collect();
-        labels.push("Custom model name...".to_string());
-        let label_refs: Vec<&str> = labels.iter().map(|s| s.as_str()).collect();
+        let mut label_refs: Vec<&str> = models.iter().map(|m| m.1).collect();
+        label_refs.push("Custom model name...");
 
         let list = SelectList::new(&label_refs, state.selected_index)
             .focused(true)
@@ -263,7 +262,7 @@ pub fn render_model_selection(frame: &mut Frame, state: &WizardState) {
             x: content_area.x + 2,
             y: content_area.y + 1,
             width: content_area.width.saturating_sub(4),
-            height: (labels.len() as u16 + 2).min(content_area.height.saturating_sub(2)),
+            height: (label_refs.len() as u16 + 2).min(content_area.height.saturating_sub(2)),
         };
         list.render(frame, list_area);
     }

--- a/feroxmute-cli/src/wizard/state.rs
+++ b/feroxmute-cli/src/wizard/state.rs
@@ -967,7 +967,6 @@ mod tests {
     #[test]
     fn test_models_for_provider_first_is_default() {
         // The first model for each provider should match generate_toml default
-        let state = test_wizard_state();
         let anthropic_models = models_for_provider(&ProviderName::Anthropic);
         let gemini_models = models_for_provider(&ProviderName::Gemini);
         let xai_models = models_for_provider(&ProviderName::Xai);
@@ -976,8 +975,6 @@ mod tests {
         assert_eq!(anthropic_models[0].0, "claude-sonnet-4-20250514");
         assert_eq!(gemini_models[0].0, "gemini-2.5-flash");
         assert_eq!(xai_models[0].0, "grok-3");
-        // Sanity check: state.generate_toml uses the same defaults
-        drop(state);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a new ModelSelection wizard screen between Provider and ApiKey with curated model lists per provider (3-4 models each) plus a "Custom model name..." option for arbitrary input
- Update outdated default models: Gemini → gemini-2.5-flash, xAI → grok-3, Cohere → command-a-03-2025, Ollama → llama4
- CLI agent providers (ClaudeCode, Codex, GeminiCli) skip the screen since they don't use model names

## Test plan
- [x] All 398 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy -- -D warnings`)
- [ ] Manual: run `cargo run -- --wizard`, verify model selection screen appears after provider selection
- [ ] Manual: verify preset selection stores model and advances
- [ ] Manual: verify "Custom..." opens text input pre-filled with default
- [ ] Manual: verify Esc from custom input returns to list
- [ ] Manual: verify CLI agent providers skip the screen

Closes #10