### PR TITLE
Update all dependencies and migrate to agent-client-protocol 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,33 +30,50 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.9.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2659b1089101b15db31137710159421cb44785ecdb5ba784be3b4a6f8cb8a475"
+checksum = "e981a7d0207a0e9eb67d0faafc04e8c6601dea572d67a3163798897c0024521d"
 dependencies = [
+ "agent-client-protocol-derive",
  "agent-client-protocol-schema",
- "anyhow",
- "async-broadcast",
- "async-trait",
- "derive_more 2.1.1",
+ "async-process",
+ "blocking",
  "futures",
- "log",
+ "futures-concurrency",
+ "rustc-hash 2.1.2",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d589c28cbe2978c76f8714cc304bc08355ee2f05d120806717725d9ffa12143"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.10.8"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bc1fef9c32f03bce2ab44af35b6f483bfd169bf55cc59beeb2e3b1a00ae4d1"
+checksum = "ac542aba230234b1591ace7286a47c0514fe3efc3037d43296bde31ba7ee5728"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
- "strum 0.27.2",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
 ]
 
 [[package]]
@@ -82,9 +99,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -101,7 +118,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba21c7f883cc76d76a41910815b1b212e1ca7870af2bd551565282140660ca5"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bitreader",
  "brotli-decompressor",
  "byteorder",
@@ -116,7 +133,7 @@ dependencies = [
  "num-traits",
  "ouroboros",
  "pathfinder_geometry",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "tinyvec",
  "ucd-trie",
  "unicode-canonical-combining-class",
@@ -135,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -150,15 +167,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -185,15 +202,24 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "as-any"
@@ -202,15 +228,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
+name = "async-channel"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
- "event-listener",
+ "concurrent-queue",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -232,8 +323,14 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -243,7 +340,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -263,15 +360,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "azul-core"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e97054285718ff1e10e2defda742f16dac599a995526f3e63a57a6c4461e44"
+checksum = "9aa50effb9e896df2bc986f640b8ec84de39a90e0e076fd22e096ce5164a7aab"
 dependencies = [
  "azul-css",
  "gl-context-loader",
@@ -282,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "azul-css"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95419a081f7afe91b3da4d10b51457a321c368e58aeae634c1ffc7c08f26bcda"
+checksum = "77ff689feae7498a351a30699cc5a4a14dc650dddaca5436d7c5b108a956b707"
 dependencies = [
  "azul-simplecss",
  "highway",
@@ -295,16 +392,16 @@ dependencies = [
 
 [[package]]
 name = "azul-layout"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d127ea81040213a60d68d253b8ed53335286a616816891d38693f3c22a97929"
+checksum = "7e40b81fed0578d2997b9e36b2830972ca852f851d5e98faf699e9273aa6b1b1"
 dependencies = [
  "allsorts",
  "azul-core",
  "azul-css",
  "base64",
  "hyphenation",
- "lru",
+ "lru 0.16.4",
  "roxmltree",
  "rust-fontconfig",
  "serde",
@@ -320,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "azul-simplecss"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78201f8943993f37a3d6d2bbe5fa9a5ab01fac09140848fee98f1551df91bb8a"
+checksum = "8259ebd5ee48a37fd8931116405456fd67efbb5435b4789e45bdbccf5d7dea7e"
 
 [[package]]
 name = "backon"
@@ -397,9 +494,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitreader"
@@ -429,10 +526,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard"
-version = "0.20.1"
+name = "blocking"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227aa051deec8d16bd9c34605e7aaf153f240e35483dd42f6f78903847934738"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bollard"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -473,19 +583,34 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytecount"
@@ -507,9 +632,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "castaway"
@@ -531,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -553,9 +678,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -577,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -587,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -599,37 +724,37 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
- "itoa 1.0.17",
+ "itoa 1.0.18",
  "rustversion",
  "ryu",
  "static_assertions",
@@ -670,6 +795,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,29 +829,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -733,7 +855,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more 2.1.1",
  "document-features",
@@ -798,7 +920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -821,7 +943,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -832,7 +954,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -843,11 +965,10 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -861,7 +982,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -883,7 +1004,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -920,13 +1041,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -970,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -982,12 +1103,6 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -1007,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "euclid"
-version = "0.22.13"
+version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
@@ -1069,10 +1184,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
+name = "fast-srgb8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "feroxmute-cli"
@@ -1120,7 +1241,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "strum 0.27.2",
+ "strum 0.28.0",
  "tar",
  "temp-env",
  "tempfile",
@@ -1147,13 +1268,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1173,6 +1293,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1238,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1253,25 +1379,38 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
+name = "futures-concurrency"
+version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1280,44 +1419,57 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1327,7 +1479,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1381,9 +1532,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1424,15 +1586,15 @@ checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
 name = "grid"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e2d4c0a8296178d8802098410ca05d86b17a10bb5ab559b3fb404c1f948220"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1440,12 +1602,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1459,12 +1627,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.11.0"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "hashbrown",
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1478,6 +1657,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1507,12 +1692,12 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
- "itoa 1.0.17",
+ "itoa 1.0.18",
 ]
 
 [[package]]
@@ -1552,9 +1737,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1565,9 +1750,8 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.17",
+ "itoa 1.0.18",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1590,15 +1774,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1709,12 +1892,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1722,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1735,9 +1919,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1749,15 +1933,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1769,15 +1953,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1807,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1817,12 +2001,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1846,32 +2043,22 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_ci"
@@ -1911,27 +2098,28 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "kasuari"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.18",
 ]
@@ -1962,9 +2150,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1974,13 +2162,11 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1996,24 +2182,24 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2032,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lopdf"
@@ -2043,19 +2229,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f560f57dfb9142a02d673e137622fd515d4231e51feb8b4af28d92647d83f35b"
 dependencies = [
  "aes",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cbc",
  "ecb",
  "encoding_rs",
  "flate2",
  "getrandom 0.3.4",
- "indexmap",
- "itoa 1.0.17",
+ "indexmap 2.14.0",
+ "itoa 1.0.18",
  "log",
  "md-5",
  "nom 8.0.0",
  "nom_locate",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rangemap",
  "sha2",
  "stringprep",
@@ -2067,11 +2253,17 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2131,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmem"
@@ -2177,7 +2369,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2214,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2240,14 +2432,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -2272,7 +2464,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2326,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2338,7 +2530,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2370,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2382,15 +2574,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2403,20 +2594,20 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -2441,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.1.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -2469,14 +2660,38 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "parking"
@@ -2502,7 +2717,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2519,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version",
 ]
@@ -2562,7 +2777,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2633,7 +2848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2660,7 +2875,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2678,52 +2893,71 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "piper"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pocket-resources"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c135f38778ad324d9e9ee68690bac2c1a51f340fdf96ca13e2ab3914eb2e51d8"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2733,9 +2967,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2763,9 +2997,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "printpdf"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb8cd4ea90275518c37c41f884d149d9e079e533417707eddde7e53bca237130"
+checksum = "b91dac59ed5eed56d899517c12cb9f00756738731926b54e513732a36f49a83d"
 dependencies = [
  "allsorts",
  "azul-core",
@@ -2828,9 +3062,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2840,6 +3074,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2857,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2868,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2959,32 +3199,36 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown",
- "indoc",
+ "critical-section",
+ "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru",
- "strum 0.27.2",
+ "lru 0.18.0",
+ "palette",
+ "serde",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -2993,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -3005,19 +3249,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
+name = "ratatui-termina"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -3025,41 +3280,22 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.10.0",
- "hashbrown",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum 0.27.2",
+ "serde",
+ "strum 0.28.0",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -3068,16 +3304,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3108,14 +3335,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3136,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3203,10 +3430,10 @@ dependencies = [
  "mime",
  "mime_guess",
  "nanoid",
- "ordered-float 5.1.0",
+ "ordered-float 5.3.0",
  "pin-project-lite",
  "reqwest",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3241,11 +3468,11 @@ dependencies = [
 
 [[package]]
 name = "rsqlite-vfs"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.1",
  "thiserror 2.0.18",
 ]
 
@@ -3255,7 +3482,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3266,14 +3493,13 @@ dependencies = [
 
 [[package]]
 name = "rust-fontconfig"
-version = "1.2.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996b6c6a909f7448e04410d370d7db66f4f30f7467214b7ac20e7c3e59ba6948"
+checksum = "ba4f18e13793c89413ba7e7c991db5f56527803d4706df6a14291d045cd67db2"
 dependencies = [
  "allsorts",
  "base64",
  "mmapio",
- "rayon",
  "xmlparser",
 ]
 
@@ -3290,6 +3516,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3300,11 +3532,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3313,9 +3545,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -3326,18 +3558,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3352,9 +3584,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3367,11 +3599,23 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3396,7 +3640,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3407,12 +3651,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3420,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3450,9 +3694,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3481,7 +3725,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3492,16 +3736,17 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "itoa 1.0.17",
+ "indexmap 2.14.0",
+ "itoa 1.0.18",
  "memchr",
  "serde",
  "serde_core",
@@ -3516,14 +3761,14 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -3535,9 +3780,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.17",
+ "itoa 1.0.18",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3571,10 +3848,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
+name = "shell-words"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -3609,9 +3892,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -3621,9 +3904,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3642,25 +3925,25 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "sqlite-wasm-rs"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
 dependencies = [
  "cc",
  "js-sys",
@@ -3733,11 +4016,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -3750,19 +4033,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3793,6 +4076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3831,7 +4120,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3840,8 +4129,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3869,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3889,12 +4178,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3912,13 +4201,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.4.3"
+name = "termina"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3950,11 +4252,11 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -3969,7 +4271,7 @@ dependencies = [
  "phf 0.11.3",
  "sha2",
  "signal-hook",
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
  "terminfo",
  "termios",
  "thiserror 1.0.69",
@@ -4026,7 +4328,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4037,7 +4339,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4051,12 +4353,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa 1.0.17",
  "libc",
  "num-conv",
  "num_threads",
@@ -4068,15 +4369,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4084,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4094,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4109,9 +4410,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4126,13 +4427,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4172,17 +4473,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4196,18 +4497,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -4226,20 +4527,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4267,11 +4568,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -4285,7 +4587,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4323,9 +4625,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4353,9 +4655,9 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -4389,9 +4691,9 @@ checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-joining-type"
@@ -4422,9 +4724,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -4493,12 +4795,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "atomic",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -4564,18 +4866,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4586,23 +4888,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4610,22 +4908,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -4645,9 +4943,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4733,13 +5031,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.0"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "env_home",
- "rustix",
- "winsafe",
+ "libc",
 ]
 
 [[package]]
@@ -4794,7 +5090,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4805,7 +5101,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4849,16 +5145,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4876,31 +5163,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4910,22 +5180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4934,22 +5192,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4958,22 +5204,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4982,46 +5216,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-
-[[package]]
-name = "winsafe"
-version = "0.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xattr"
@@ -5047,9 +5269,9 @@ checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5058,68 +5280,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5128,9 +5350,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5139,17 +5361,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ dependencies = [
  "once_cell",
  "printpdf",
  "regex",
+ "reqwest",
  "rig-core",
  "rusqlite",
  "serde",

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Instead of calling LLM APIs directly, feroxmute can drive CLI-based AI agents as
 
 | Provider | Binary | Auth |
 |----------|--------|------|
-| `claude-code` | `claude-code-acp` | `ANTHROPIC_API_KEY` or `claude login` |
+| `claude-code` | [`cc-acp`](https://www.npmjs.com/package/claude-code-acp) (from the `claude-code-acp` package) | `ANTHROPIC_API_KEY` or `claude login` |
 | `codex` | [`codex-acp`](https://github.com/zed-industries/codex-acp) | `OPENAI_API_KEY`, `CODEX_API_KEY`, or existing Codex auth |
 | `gemini-cli` | `gemini` | `gemini auth` |
 
@@ -158,7 +158,7 @@ Instead of calling LLM APIs directly, feroxmute can drive CLI-based AI agents as
 If the CLI agent binary isn't on your `$PATH`, use `--cli-path`:
 
 ```bash
-feroxmute --target example.com --provider claude-code --cli-path ~/bin/claude-code-acp
+feroxmute --target example.com --provider claude-code --cli-path ~/.bun/bin/cc-acp
 feroxmute --target example.com --provider codex --cli-path ~/bin/codex-acp
 ```
 

--- a/README.md
+++ b/README.md
@@ -149,16 +149,20 @@ Instead of calling LLM APIs directly, feroxmute can drive CLI-based AI agents as
 
 | Provider | Binary | Auth |
 |----------|--------|------|
-| `claude-code` | [`cc-acp`](https://www.npmjs.com/package/claude-code-acp) (from the `claude-code-acp` package) | `ANTHROPIC_API_KEY` or `claude login` |
+| `claude-code` | [`claude-code-acp`](https://www.npmjs.com/package/@zed-industries/claude-code-acp) (from `@zed-industries/claude-code-acp`) | `ANTHROPIC_API_KEY` or `claude login` |
 | `codex` | [`codex-acp`](https://github.com/zed-industries/codex-acp) | `OPENAI_API_KEY`, `CODEX_API_KEY`, or existing Codex auth |
 | `gemini-cli` | `gemini` | `gemini auth` |
+
+> Install the Claude Code adapter with `bun install -g @zed-industries/claude-code-acp`.
+> The unscoped `claude-code-acp` package on npm is a different, incomplete adapter
+> (it rejects MCP servers) — make sure you install the `@zed-industries`-scoped one.
 
 ### Custom Binary Path
 
 If the CLI agent binary isn't on your `$PATH`, use `--cli-path`:
 
 ```bash
-feroxmute --target example.com --provider claude-code --cli-path ~/.bun/bin/cc-acp
+feroxmute --target example.com --provider claude-code --cli-path ~/.bun/bin/claude-code-acp
 feroxmute --target example.com --provider codex --cli-path ~/bin/codex-acp
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     hashcat \
     john \
     commix \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 # Install ProjectDiscovery tools via pdtm
@@ -90,14 +91,16 @@ RUN curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh |
 # Install Trivy for container/dependency scanning
 RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
 
-# Install Node.js for promptfoo
+# Install Node.js (runtime for promptfoo) and bun (package manager)
 RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
 
 # LLM Penetration Testing Tools
 RUN uv pip install --system --break-system-packages garak pyrit && \
-    npm install -g promptfoo
+    bun install -g promptfoo
 
 # Create working directories
 RUN mkdir -p /feroxmute/workdir/{orchestrator,recon,scanner,exploit,llm_pentest,scripts} \

--- a/feroxmute-cli/src/args.rs
+++ b/feroxmute-cli/src/args.rs
@@ -123,4 +123,16 @@ pub struct Args {
     /// Skip network testing, only test the target LLM
     #[arg(long)]
     pub llm_only: bool,
+
+    /// Internal: run as an stdio↔HTTP MCP proxy for stdio-only ACP agents.
+    ///
+    /// Used automatically by feroxmute when a CLI agent (e.g. claude-code)
+    /// only supports stdio MCP servers. The bearer token is read from the
+    /// `FEROXMUTE_MCP_TOKEN` environment variable.
+    #[arg(long, hide = true)]
+    pub mcp_stdio_proxy: bool,
+
+    /// Internal: HTTP MCP server URL for `--mcp-stdio-proxy`.
+    #[arg(long, hide = true, value_name = "URL")]
+    pub mcp_proxy_url: Option<String>,
 }

--- a/feroxmute-cli/src/main.rs
+++ b/feroxmute-cli/src/main.rs
@@ -249,7 +249,7 @@ async fn main() -> Result<()> {
         }
         ProviderName::Ollama => "Set OLLAMA_API_BASE_URL if not using localhost:11434",
         ProviderName::ClaudeCode => {
-            "Install claude-code-acp in PATH or pass --cli-path, then run 'claude login'"
+            "Install the claude-code-acp package (provides the 'cc-acp' binary) in PATH or pass --cli-path, then run 'claude login'"
         }
         ProviderName::Codex => {
             "Install codex-acp in PATH or pass --cli-path /path/to/codex-acp, then authenticate with OPENAI_API_KEY, CODEX_API_KEY, or Codex auth"

--- a/feroxmute-cli/src/main.rs
+++ b/feroxmute-cli/src/main.rs
@@ -262,7 +262,7 @@ async fn main() -> Result<()> {
         }
         ProviderName::Ollama => "Set OLLAMA_API_BASE_URL if not using localhost:11434",
         ProviderName::ClaudeCode => {
-            "Install the claude-code-acp package (provides the 'cc-acp' binary) in PATH or pass --cli-path, then run 'claude login'"
+            "Install the ACP adapter: 'bun install -g @zed-industries/claude-code-acp' (provides the 'claude-code-acp' binary), or pass --cli-path, then run 'claude login'"
         }
         ProviderName::Codex => {
             "Install codex-acp in PATH or pass --cli-path /path/to/codex-acp, then authenticate with OPENAI_API_KEY, CODEX_API_KEY, or Codex auth"

--- a/feroxmute-cli/src/main.rs
+++ b/feroxmute-cli/src/main.rs
@@ -91,6 +91,19 @@ fn find_session_by_pattern(
 async fn main() -> Result<()> {
     let args = Args::parse();
 
+    // stdio MCP proxy mode: bridge an stdio-only ACP agent to feroxmute's
+    // HTTP MCP server. Must not touch stdout (it is the MCP channel) or set up
+    // the normal logging/TUI, so handle it before anything else.
+    if args.mcp_stdio_proxy {
+        let url = args
+            .mcp_proxy_url
+            .ok_or_else(|| anyhow!("--mcp-stdio-proxy requires --mcp-proxy-url"))?;
+        let token =
+            std::env::var(feroxmute_core::mcp::stdio_proxy::MCP_TOKEN_ENV).unwrap_or_default();
+        feroxmute_core::mcp::run_stdio_proxy(url, token).await?;
+        return Ok(());
+    }
+
     // Set up tracing based on verbosity
     let filter = if args.debug {
         "debug"

--- a/feroxmute-core/Cargo.toml
+++ b/feroxmute-core/Cargo.toml
@@ -32,6 +32,7 @@ which = "8.0.0"
 hyper-util.workspace = true
 http-body-util.workspace = true
 strum = { version = "0.28", features = ["derive"] }
+reqwest = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/feroxmute-core/Cargo.toml
+++ b/feroxmute-core/Cargo.toml
@@ -27,11 +27,11 @@ once_cell = "1.21.3"
 backon.workspace = true
 walkdir = "2"
 printpdf = "0.9"
-agent-client-protocol = { version = "0.9.4", features = ["unstable"] }
+agent-client-protocol = { version = "1.0", features = ["unstable"] }
 which = "8.0.0"
 hyper-util.workspace = true
 http-body-util.workspace = true
-strum = { version = "0.27.2", features = ["derive"] }
+strum = { version = "0.28", features = ["derive"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/feroxmute-core/src/mcp/mod.rs
+++ b/feroxmute-core/src/mcp/mod.rs
@@ -5,9 +5,11 @@
 pub mod http;
 mod protocol;
 mod server;
+pub mod stdio_proxy;
 pub mod tools;
 mod transport;
 
 pub use protocol::*;
 pub use server::*;
+pub use stdio_proxy::run_stdio_proxy;
 pub use transport::*;

--- a/feroxmute-core/src/mcp/stdio_proxy.rs
+++ b/feroxmute-core/src/mcp/stdio_proxy.rs
@@ -1,0 +1,260 @@
+//! stdio ↔ HTTP MCP proxy.
+//!
+//! Some ACP agents (notably `claude-code-acp`) only support **stdio** MCP
+//! servers — they spawn a subprocess and speak MCP over its stdin/stdout.
+//! feroxmute serves its tools over an in-process HTTP MCP server
+//! ([`crate::mcp::http::HttpMcpServer`]) whose tools hold live engagement
+//! context (the Docker container, event channel, database), so that context
+//! cannot be recreated in a separate process.
+//!
+//! This proxy bridges the gap: feroxmute attaches itself as a stdio MCP
+//! server whose command re-invokes the feroxmute binary in proxy mode. The
+//! proxy reads newline-delimited JSON-RPC from stdin, forwards each message to
+//! the HTTP MCP server (with the bearer token), and writes the response back
+//! to stdout. All tool execution still happens in the main feroxmute process.
+
+use serde_json::Value;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+
+use crate::Result;
+
+/// Environment variable carrying the HTTP MCP bearer token to the proxy.
+pub const MCP_TOKEN_ENV: &str = "FEROXMUTE_MCP_TOKEN";
+
+/// Run the stdio ↔ HTTP MCP proxy until stdin reaches EOF.
+///
+/// `url` is the feroxmute HTTP MCP server URL; `token` is its bearer token.
+/// Newline-delimited JSON-RPC requests on stdin are forwarded to the server;
+/// responses are written back to stdout. Notification requests (those the
+/// server answers with an empty body) produce no stdout, per the MCP spec.
+///
+/// # Errors
+///
+/// Returns an error only if stdin/stdout I/O fails; per-request HTTP failures
+/// are reported back to the client as JSON-RPC error responses so the agent
+/// is never left waiting.
+pub async fn run_stdio_proxy(url: String, token: String) -> Result<()> {
+    let reader = BufReader::new(tokio::io::stdin());
+    let mut stdout = tokio::io::stdout();
+    proxy_io(reader, &mut stdout, &url, &token).await
+}
+
+/// Core proxy loop, generic over the I/O streams so it can be tested with
+/// in-memory buffers against a real [`crate::mcp::http::HttpMcpServer`].
+async fn proxy_io<R, W>(reader: R, writer: &mut W, url: &str, token: &str) -> Result<()>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let client = reqwest::Client::new();
+    let bearer = format!("Bearer {token}");
+    let mut lines = reader.lines();
+
+    while let Some(line) = lines
+        .next_line()
+        .await
+        .map_err(|e| crate::Error::Provider(format!("MCP proxy stdin read failed: {e}")))?
+    {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        match forward(&client, url, &bearer, line).await {
+            ForwardOutcome::Response(body) => {
+                write_line(writer, body.trim_end().as_bytes()).await?;
+            }
+            // Notification (empty/202 body): MCP expects no reply.
+            ForwardOutcome::NoReply => {}
+            ForwardOutcome::Failed(message) => {
+                let id = serde_json::from_str::<Value>(line)
+                    .ok()
+                    .and_then(|v| v.get("id").cloned())
+                    .unwrap_or(Value::Null);
+                let error = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": { "code": -32603, "message": message }
+                });
+                write_line(writer, error.to_string().as_bytes()).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn write_line<W: AsyncWrite + Unpin>(writer: &mut W, bytes: &[u8]) -> Result<()> {
+    writer.write_all(bytes).await.map_err(|e| write_err(&e))?;
+    writer.write_all(b"\n").await.map_err(|e| write_err(&e))?;
+    writer.flush().await.map_err(|e| write_err(&e))?;
+    Ok(())
+}
+
+enum ForwardOutcome {
+    Response(String),
+    NoReply,
+    Failed(String),
+}
+
+async fn forward(client: &reqwest::Client, url: &str, bearer: &str, body: &str) -> ForwardOutcome {
+    let response = client
+        .post(url)
+        .header(reqwest::header::AUTHORIZATION, bearer)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .body(body.to_string())
+        .send()
+        .await;
+
+    let response = match response {
+        Ok(r) => r,
+        Err(e) => {
+            return ForwardOutcome::Failed(format!("feroxmute MCP proxy request failed: {e}"));
+        }
+    };
+
+    let status = response.status();
+    let text = match response.text().await {
+        Ok(t) => t,
+        Err(e) => {
+            return ForwardOutcome::Failed(format!(
+                "feroxmute MCP proxy failed to read response: {e}"
+            ));
+        }
+    };
+
+    if !status.is_success() {
+        return ForwardOutcome::Failed(format!(
+            "feroxmute MCP server returned HTTP {status}: {}",
+            text.trim()
+        ));
+    }
+
+    if text.trim().is_empty() {
+        ForwardOutcome::NoReply
+    } else {
+        ForwardOutcome::Response(text)
+    }
+}
+
+fn write_err(e: &std::io::Error) -> crate::Error {
+    crate::Error::Provider(format!("MCP proxy stdout write failed: {e}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::mcp::http::HttpMcpServer;
+    use crate::mcp::protocol::McpToolResult;
+    use crate::mcp::{McpServer, McpTool};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct EchoTool;
+
+    #[async_trait]
+    impl McpTool for EchoTool {
+        fn name(&self) -> &str {
+            "echo"
+        }
+        fn description(&self) -> &str {
+            "Echoes the message back"
+        }
+        fn input_schema(&self) -> Value {
+            serde_json::json!({"type": "object", "properties": {"message": {"type": "string"}}})
+        }
+        async fn execute(&self, arguments: Value) -> Result<McpToolResult> {
+            let msg = arguments
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            Ok(McpToolResult::text(msg))
+        }
+    }
+
+    async fn start_server() -> HttpMcpServer {
+        let server = Arc::new(McpServer::new("test", "1.0.0"));
+        server.register_tool(Arc::new(EchoTool)).await;
+        HttpMcpServer::start(server).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_proxy_forwards_request_and_returns_response() {
+        let http = start_server().await;
+
+        let input = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n".to_vec();
+        let mut output = Vec::new();
+        proxy_io(&input[..], &mut output, &http.url(), http.token())
+            .await
+            .unwrap();
+
+        let out = String::from_utf8(output).unwrap();
+        let response: Value = serde_json::from_str(out.trim()).unwrap();
+        assert_eq!(response["id"], 1);
+        let tool_names: Vec<&str> = response["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t["name"].as_str())
+            .collect();
+        assert!(
+            tool_names.contains(&"echo"),
+            "tools/list should expose echo"
+        );
+
+        http.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_proxy_tool_call_round_trip() {
+        let http = start_server().await;
+
+        let input =
+            b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"echo\",\"arguments\":{\"message\":\"hi there\"}}}\n"
+                .to_vec();
+        let mut output = Vec::new();
+        proxy_io(&input[..], &mut output, &http.url(), http.token())
+            .await
+            .unwrap();
+
+        let out = String::from_utf8(output).unwrap();
+        assert!(
+            out.contains("hi there"),
+            "echoed text should round-trip: {out}"
+        );
+
+        http.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_proxy_notification_produces_no_output() {
+        let http = start_server().await;
+
+        // No `id` -> the server treats it as a notification (202, empty body).
+        let input = b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n".to_vec();
+        let mut output = Vec::new();
+        proxy_io(&input[..], &mut output, &http.url(), http.token())
+            .await
+            .unwrap();
+
+        assert!(output.is_empty(), "notifications must not get a reply");
+
+        http.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_proxy_reports_connection_failure_as_jsonrpc_error() {
+        let input = b"{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"tools/list\"}\n".to_vec();
+        let mut output = Vec::new();
+        // Port 1 is unbound -> request fails.
+        proxy_io(&input[..], &mut output, "http://127.0.0.1:1/mcp", "tok")
+            .await
+            .unwrap();
+
+        let response: Value =
+            serde_json::from_str(String::from_utf8(output).unwrap().trim()).unwrap();
+        assert_eq!(response["id"], 9);
+        assert_eq!(response["error"]["code"], -32603);
+    }
+}

--- a/feroxmute-core/src/providers/cli_agent/bridge.rs
+++ b/feroxmute-core/src/providers/cli_agent/bridge.rs
@@ -18,11 +18,11 @@ use std::time::Duration;
 
 use acp::schema::ProtocolVersion;
 use acp::schema::v1::{
-    CancelNotification, ContentBlock, HttpHeader, Implementation, InitializeRequest,
-    McpCapabilities, McpServer, McpServerHttp, NewSessionRequest, PermissionOptionKind,
-    PromptRequest, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    SelectedPermissionOutcome, SessionId, SessionNotification, SessionUpdate, TextContent,
-    ToolCallStatus,
+    CancelNotification, ContentBlock, EnvVariable, HttpHeader, Implementation, InitializeRequest,
+    McpCapabilities, McpServer, McpServerHttp, McpServerStdio, NewSessionRequest,
+    PermissionOptionKind, PromptRequest, RequestPermissionOutcome, RequestPermissionRequest,
+    RequestPermissionResponse, SelectedPermissionOutcome, SessionId, SessionNotification,
+    SessionUpdate, TextContent, ToolCallStatus,
 };
 use acp::{Agent, ByteStreams, Client, ConnectionTo};
 use agent_client_protocol as acp;
@@ -702,7 +702,7 @@ async fn run_standard_protocol(
             } => {
                 tracing::debug!("Creating standard ACP session for role '{agent_role}'");
                 let request = NewSessionRequest::new(&working_dir);
-                let result = match attach_http_mcp_server(
+                let result = match attach_mcp_server(
                     request,
                     mcp_server_url,
                     bearer_token,
@@ -744,8 +744,8 @@ async fn run_standard_protocol(
     }
 }
 
-fn attach_http_mcp_server(
-    mut request: NewSessionRequest,
+fn attach_mcp_server(
+    request: NewSessionRequest,
     mcp_server_url: Option<String>,
     bearer_token: Option<String>,
     mcp_capabilities: &McpCapabilities,
@@ -755,25 +755,50 @@ fn attach_http_mcp_server(
         return Ok(request);
     };
 
-    if !mcp_capabilities.http {
-        return Err(crate::Error::Provider(format!(
-            "{provider_name} ACP adapter does not advertise HTTP MCP support, \
-             so feroxmute cannot attach its tool server. Update the ACP adapter \
-             or use a provider that supports ACP HTTP MCP servers."
-        )));
-    }
+    // Prefer HTTP when the agent advertises it; otherwise fall back to a stdio
+    // MCP server (which every ACP agent MUST support). The stdio server is
+    // feroxmute re-invoked in proxy mode, bridging stdio MCP to this same HTTP
+    // server so tools keep executing in the main process.
+    let mcp_server = if mcp_capabilities.http {
+        tracing::debug!("Attaching HTTP MCP server at {}", url);
+        let mut mcp_http = McpServerHttp::new("feroxmute", url);
+        if let Some(token) = bearer_token {
+            mcp_http = mcp_http.headers(vec![HttpHeader::new(
+                "Authorization",
+                format!("Bearer {token}"),
+            )]);
+        }
+        McpServer::Http(mcp_http)
+    } else {
+        tracing::debug!(
+            "{provider_name} does not advertise HTTP MCP support; attaching stdio MCP proxy to {}",
+            url
+        );
+        let exe = std::env::current_exe().map_err(|e| {
+            crate::Error::Provider(format!(
+                "Cannot locate feroxmute executable to launch the stdio MCP proxy for \
+                 {provider_name}: {e}"
+            ))
+        })?;
+        let env = match bearer_token {
+            Some(token) => vec![EnvVariable::new(
+                crate::mcp::stdio_proxy::MCP_TOKEN_ENV,
+                token,
+            )],
+            None => Vec::new(),
+        };
+        McpServer::Stdio(
+            McpServerStdio::new("feroxmute", exe)
+                .args(vec![
+                    "--mcp-stdio-proxy".to_string(),
+                    "--mcp-proxy-url".to_string(),
+                    url,
+                ])
+                .env(env),
+        )
+    };
 
-    tracing::debug!("Attaching MCP server at {}", url);
-    let mut mcp_http = McpServerHttp::new("feroxmute", url);
-    if let Some(token) = bearer_token {
-        mcp_http = mcp_http.headers(vec![HttpHeader::new(
-            "Authorization",
-            format!("Bearer {token}"),
-        )]);
-    }
-    request = request.mcp_servers(vec![McpServer::Http(mcp_http)]);
-
-    Ok(request)
+    Ok(request.mcp_servers(vec![mcp_server]))
 }
 
 async fn standard_new_session(

--- a/feroxmute-core/src/providers/cli_agent/bridge.rs
+++ b/feroxmute-core/src/providers/cli_agent/bridge.rs
@@ -1,9 +1,11 @@
 //! Thread-safe bridge to the ACP client.
 //!
-//! The ACP SDK's `ClientSideConnection` uses `LocalBoxFuture` (requires `spawn_local`
-//! / `LocalSet`), but `LlmProvider: Send + Sync` needs `Send` futures. This bridge
-//! runs all ACP operations on a dedicated `std::thread` with a `current_thread`
-//! tokio runtime + `LocalSet`, communicating via channels.
+//! The ACP SDK drives a connection through actors that run for the lifetime of
+//! a single `connect_with` call, and the Gemini flavor uses `spawn_local`. Both
+//! need a `current_thread` runtime + `LocalSet`, but `LlmProvider: Send + Sync`
+//! needs `Send` futures. This bridge runs all ACP operations on a dedicated
+//! `std::thread` with a `current_thread` tokio runtime + `LocalSet`, communicating
+//! via channels.
 
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
@@ -14,12 +16,20 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use acp::Agent; // Required for initialize, prompt, new_session, cancel
+use acp::schema::ProtocolVersion;
+use acp::schema::v1::{
+    CancelNotification, ContentBlock, HttpHeader, Implementation, InitializeRequest,
+    McpCapabilities, McpServer, McpServerHttp, NewSessionRequest, PermissionOptionKind,
+    PromptRequest, RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    SelectedPermissionOutcome, SessionId, SessionNotification, SessionUpdate, TextContent,
+    ToolCallStatus,
+};
+use acp::{Agent, ByteStreams, Client, ConnectionTo};
 use agent_client_protocol as acp;
 use futures::io::AsyncWriteExt;
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::{Child, Command};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 use tokio::sync::{Mutex, Notify, mpsc, oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -40,21 +50,21 @@ enum AcpCommand {
         working_dir: PathBuf,
         mcp_server_url: Option<String>,
         bearer_token: Option<String>,
-        reply: oneshot::Sender<Result<acp::SessionId>>,
+        reply: oneshot::Sender<Result<SessionId>>,
     },
     Prompt {
-        session_id: acp::SessionId,
+        session_id: SessionId,
         message: String,
         reply: oneshot::Sender<Result<String>>,
     },
     Cancel {
-        session_id: acp::SessionId,
+        session_id: SessionId,
     },
     Shutdown,
 }
 
 // ---------------------------------------------------------------------------
-// Response collector (single-threaded, lives inside bridge thread)
+// Response collector
 // ---------------------------------------------------------------------------
 
 const ACP_PROMPT_IDLE_TIMEOUT: Duration = Duration::from_secs(300);
@@ -82,6 +92,21 @@ impl ResponseCollector {
     }
 }
 
+/// Shared collector used by both the Standard (SDK) and Gemini paths.
+///
+/// The Standard path's notification callback must be `Send`, so the collector
+/// is wrapped in an `Arc<std::sync::Mutex<_>>` rather than `Rc<RefCell<_>>`.
+type SharedCollector = Arc<std::sync::Mutex<ResponseCollector>>;
+
+/// Lock the collector, recovering from poisoning rather than panicking.
+fn lock_collector(
+    collector: &std::sync::Mutex<ResponseCollector>,
+) -> std::sync::MutexGuard<'_, ResponseCollector> {
+    collector
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// A custom connection for Gemini CLI which uses a slightly different ACP flavor.
 struct GeminiConnection {
     stdin: Arc<Mutex<tokio_util::compat::Compat<tokio::process::ChildStdin>>>,
@@ -90,16 +115,6 @@ struct GeminiConnection {
     /// Signaled by the stdout reader whenever the agent shows activity (notifications,
     /// agent-initiated requests). Used to reset the idle timeout in `call()`.
     activity: Arc<Notify>,
-}
-
-/// Standard ACP connection state.
-struct StandardConnection {
-    conn: acp::ClientSideConnection,
-    /// Signaled by the ACP delegate whenever the agent emits a notification or
-    /// client request. Used to reset the idle timeout for `session/prompt`.
-    activity: Rc<Notify>,
-    diagnostics: Rc<RefCell<CliDiagnostics>>,
-    mcp_capabilities: acp::McpCapabilities,
 }
 
 #[derive(Default)]
@@ -266,11 +281,6 @@ impl GeminiConnection {
     }
 }
 
-enum Connection {
-    Standard(StandardConnection),
-    Gemini(GeminiConnection),
-}
-
 // ---------------------------------------------------------------------------
 // AcpBridge (Send + Sync wrapper)
 // ---------------------------------------------------------------------------
@@ -331,7 +341,7 @@ impl AcpBridge {
         working_dir: &Path,
         mcp_server_url: Option<String>,
         bearer_token: Option<String>,
-    ) -> Result<acp::SessionId> {
+    ) -> Result<SessionId> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(AcpCommand::NewSession {
@@ -348,7 +358,7 @@ impl AcpBridge {
     }
 
     /// Send a prompt to a session and wait for the complete response.
-    pub async fn prompt(&self, session_id: &acp::SessionId, message: &str) -> Result<String> {
+    pub async fn prompt(&self, session_id: &SessionId, message: &str) -> Result<String> {
         let (tx, rx) = oneshot::channel();
         self.cmd_tx
             .send(AcpCommand::Prompt {
@@ -363,7 +373,7 @@ impl AcpBridge {
     }
 
     /// Cancel an active session.
-    pub async fn cancel(&self, session_id: &acp::SessionId) {
+    pub async fn cancel(&self, session_id: &SessionId) {
         let _ = self
             .cmd_tx
             .send(AcpCommand::Cancel {
@@ -404,28 +414,283 @@ fn build_bridge_runtime() -> tokio::runtime::Runtime {
 // Bridge thread internals
 // ---------------------------------------------------------------------------
 
+fn not_connected() -> crate::Error {
+    crate::Error::Provider("ACP client not connected".to_string())
+}
+
 /// Main event loop that runs inside the bridge thread's `LocalSet`.
+///
+/// Waits for the initial `Connect`, then hands control to the per-flavor
+/// command loop, which owns the connection for its lifetime. The Standard
+/// (SDK) path drives the connection inside an `connect_with` closure; the
+/// Gemini path uses a long-lived manual JSON-RPC connection.
 async fn command_loop(mut cmd_rx: mpsc::Receiver<AcpCommand>, config: CliAgentConfig) {
-    let mut child: Option<Child> = None;
-    let mut connection: Option<Connection> = None;
-    let collector = Rc::new(RefCell::new(ResponseCollector::default()));
+    let collector: SharedCollector = Arc::new(std::sync::Mutex::new(ResponseCollector::default()));
 
     while let Some(cmd) = cmd_rx.recv().await {
         match cmd {
             AcpCommand::Connect { working_dir, reply } => {
-                let result = do_connect(&config, &working_dir, &collector).await;
-                match result {
-                    Ok((c, conn)) => {
-                        child = Some(c);
-                        connection = Some(conn);
-                        let _ = reply.send(Ok(()));
-                    }
+                let child_io = match prepare_child(&config, &working_dir) {
+                    Ok(io) => io,
                     Err(e) => {
                         let _ = reply.send(Err(e));
+                        continue;
                     }
+                };
+
+                if config.agent_type == CliAgentType::GeminiCli {
+                    match connect_gemini(child_io, &collector).await {
+                        Ok((child, conn)) => {
+                            let _ = reply.send(Ok(()));
+                            gemini_command_loop(&mut cmd_rx, child, conn, &collector).await;
+                            return;
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(e));
+                            continue;
+                        }
+                    }
+                } else {
+                    standard_session(&mut cmd_rx, child_io, reply, &collector, &config).await;
+                    return;
                 }
             }
+            AcpCommand::Shutdown => return,
+            AcpCommand::NewSession { reply, .. } => {
+                let _ = reply.send(Err(not_connected()));
+            }
+            AcpCommand::Prompt { reply, .. } => {
+                let _ = reply.send(Err(not_connected()));
+            }
+            AcpCommand::Cancel { .. } => {}
+        }
+    }
+}
 
+/// Captured subprocess I/O handles for an established CLI agent process.
+struct ChildIo {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: ChildStdout,
+    diagnostics: Rc<RefCell<CliDiagnostics>>,
+}
+
+/// Spawn the CLI subprocess and capture its stdio.
+///
+/// For CLI agents that use ACP adapters (e.g. `claude-code-acp`), the binary
+/// speaks ACP natively over stdin/stdout. MCP servers are provided later via
+/// `NewSessionRequest.mcp_servers` rather than CLI flags.
+fn prepare_child(config: &CliAgentConfig, working_dir: &Path) -> Result<ChildIo> {
+    // Check binary availability first
+    if which::which(&config.binary_path).is_err() {
+        return Err(crate::Error::Provider(format!(
+            "{} CLI not found at '{}'. Install it or specify path with --cli-path. Auth hint: {}",
+            config.agent_type.provider_name(),
+            config.binary_path.display(),
+            config.agent_type.auth_hint()
+        )));
+    }
+
+    let mut cmd = Command::new(&config.binary_path);
+    cmd.current_dir(working_dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    match config.agent_type {
+        CliAgentType::Codex => {
+            cmd.arg("-c")
+                .arg(format!("model={}", toml_string_literal(&config.model)));
+        }
+        CliAgentType::GeminiCli => {
+            cmd.arg("--experimental-acp");
+            cmd.arg("-m").arg(&config.model);
+        }
+        CliAgentType::ClaudeCode => {}
+    }
+
+    let mut child = cmd.spawn().map_err(|e| {
+        crate::Error::Provider(format!(
+            "Failed to spawn {} CLI: {e}",
+            config.agent_type.provider_name(),
+        ))
+    })?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| crate::Error::Provider("Failed to capture CLI stdin".to_string()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| crate::Error::Provider("Failed to capture CLI stdout".to_string()))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| crate::Error::Provider("Failed to capture CLI stderr".to_string()))?;
+
+    let diagnostics = Rc::new(RefCell::new(CliDiagnostics::default()));
+    let diagnostics_for_stderr = Rc::clone(&diagnostics);
+
+    // Log stderr in a background task
+    tokio::task::spawn_local(async move {
+        let mut reader = tokio::io::BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = reader.next_line().await {
+            diagnostics_for_stderr
+                .borrow_mut()
+                .push_stderr(line.clone());
+            tracing::warn!("CLI STDERR: {}", line);
+        }
+    });
+
+    Ok(ChildIo {
+        child,
+        stdin,
+        stdout,
+        diagnostics,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Standard ACP path (SDK-driven)
+// ---------------------------------------------------------------------------
+
+/// Establish a Standard ACP connection and run the command loop for its lifetime.
+///
+/// The SDK drives the connection through actors that live only while the
+/// `connect_with` closure runs, so the per-session command loop runs *inside*
+/// that closure. Permission and notification handling is registered as builder
+/// callbacks, which must be `Send` — hence the `Arc`-based shared collector.
+async fn standard_session(
+    cmd_rx: &mut mpsc::Receiver<AcpCommand>,
+    child_io: ChildIo,
+    connect_reply: oneshot::Sender<Result<()>>,
+    collector: &SharedCollector,
+    config: &CliAgentConfig,
+) {
+    let ChildIo {
+        mut child,
+        stdin,
+        stdout,
+        diagnostics,
+    } = child_io;
+
+    let activity = Arc::new(Notify::new());
+    let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());
+
+    let run = Client
+        .builder()
+        .on_receive_notification(
+            {
+                let collector = Arc::clone(collector);
+                let activity = Arc::clone(&activity);
+                move |notification: SessionNotification, _cx: ConnectionTo<Agent>| {
+                    let collector = Arc::clone(&collector);
+                    let activity = Arc::clone(&activity);
+                    async move {
+                        activity.notify_waiters();
+                        handle_standard_notification(&collector, notification);
+                        Ok(())
+                    }
+                }
+            },
+            acp::on_receive_notification!(),
+        )
+        .on_receive_request(
+            {
+                let activity = Arc::clone(&activity);
+                move |request: RequestPermissionRequest,
+                      responder: acp::Responder<RequestPermissionResponse>,
+                      _cx: ConnectionTo<Agent>| {
+                    let activity = Arc::clone(&activity);
+                    async move {
+                        activity.notify_waiters();
+                        let option_id = pick_permission_option(&request);
+                        tracing::debug!("ACP request_permission auto-approved with '{option_id}'");
+                        responder.respond(RequestPermissionResponse::new(
+                            RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(
+                                option_id,
+                            )),
+                        ))
+                    }
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .connect_with(transport, |connection: ConnectionTo<Agent>| async move {
+            run_standard_protocol(
+                connection,
+                cmd_rx,
+                collector,
+                &activity,
+                &diagnostics,
+                connect_reply,
+                config,
+            )
+            .await;
+            Ok(())
+        })
+        .await;
+
+    if let Err(e) = run {
+        tracing::error!("ACP connection ended with error: {e}");
+    }
+    let _ = child.kill().await;
+}
+
+/// Drive the Standard ACP protocol: initialize, then handle commands until shutdown.
+///
+/// Runs as the `connect_with` main function, concurrently with the connection's
+/// background actors, so `block_task()` resolves normally here.
+async fn run_standard_protocol(
+    connection: ConnectionTo<Agent>,
+    cmd_rx: &mut mpsc::Receiver<AcpCommand>,
+    collector: &SharedCollector,
+    activity: &Arc<Notify>,
+    diagnostics: &Rc<RefCell<CliDiagnostics>>,
+    connect_reply: oneshot::Sender<Result<()>>,
+    config: &CliAgentConfig,
+) {
+    let provider_name = config.agent_type.provider_name();
+
+    // Initialize the connection.
+    let init = connection
+        .send_request(
+            InitializeRequest::new(ProtocolVersion::V1)
+                .client_info(Implementation::new("feroxmute", env!("CARGO_PKG_VERSION"))),
+        )
+        .block_task()
+        .await;
+
+    let mcp_capabilities: McpCapabilities = match init {
+        Ok(response) => {
+            let caps = response.agent_capabilities.mcp_capabilities.clone();
+            tracing::info!(
+                "Connected to {} (protocol version: {:?}, mcp_http: {}, mcp_sse: {})",
+                provider_name,
+                response.protocol_version,
+                caps.http,
+                caps.sse
+            );
+            diagnostics
+                .borrow_mut()
+                .push_rpc_event("-> initialize ok".to_string());
+            let _ = connect_reply.send(Ok(()));
+            caps
+        }
+        Err(e) => {
+            let _ = connect_reply.send(Err(crate::Error::Provider(format!(
+                "ACP initialization failed: {e}"
+            ))));
+            return;
+        }
+    };
+
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            AcpCommand::Connect { reply, .. } => {
+                let _ = reply.send(Ok(()));
+            }
             AcpCommand::NewSession {
                 agent_role,
                 working_dir,
@@ -433,181 +698,57 @@ async fn command_loop(mut cmd_rx: mpsc::Receiver<AcpCommand>, config: CliAgentCo
                 bearer_token,
                 reply,
             } => {
-                let result = match connection.as_ref() {
-                    Some(Connection::Standard(conn)) => {
-                        tracing::debug!("Creating standard ACP session for role '{}'", agent_role);
-                        let request = acp::NewSessionRequest::new(&working_dir);
-                        match attach_http_mcp_server(
-                            request,
-                            mcp_server_url,
-                            bearer_token,
-                            &conn.mcp_capabilities,
-                            config.agent_type.provider_name(),
-                        ) {
-                            Ok(request) => {
-                                standard_new_session_with_timeout(
-                                    conn,
-                                    request,
-                                    config.agent_type.provider_name(),
-                                )
-                                .await
-                            }
-                            Err(e) => Err(e),
-                        }
+                tracing::debug!("Creating standard ACP session for role '{agent_role}'");
+                let request = NewSessionRequest::new(&working_dir);
+                let result = match attach_http_mcp_server(
+                    request,
+                    mcp_server_url,
+                    bearer_token,
+                    &mcp_capabilities,
+                    provider_name,
+                ) {
+                    Ok(request) => {
+                        standard_new_session(&connection, request, provider_name, diagnostics).await
                     }
-                    Some(Connection::Gemini(conn)) => {
-                        tracing::debug!("Creating Gemini ACP session for role '{}'", agent_role);
-                        let mut mcp_servers = Vec::new();
-                        if let Some(url) = mcp_server_url {
-                            let mut headers = vec![];
-                            if let Some(ref token) = bearer_token {
-                                headers.push(json!({
-                                    "name": "Authorization",
-                                    "value": format!("Bearer {token}")
-                                }));
-                            }
-                            mcp_servers.push(json!({
-                                "name": "feroxmute",
-                                "type": "http",
-                                "url": url,
-                                "headers": headers
-                            }));
-                        }
-
-                        tracing::debug!(
-                            "Gemini: calling session/new with {} MCP server(s)",
-                            mcp_servers.len()
-                        );
-                        let result = conn
-                            .call(
-                                "session/new",
-                                json!({
-                                    "cwd": working_dir.to_string_lossy(),
-                                    "mcpServers": mcp_servers
-                                }),
-                            )
-                            .await;
-
-                        match result {
-                            Ok(res) => {
-                                tracing::debug!("Gemini session/new returned: {res}");
-                                if let Some(sid) = res.get("sessionId").and_then(|v| v.as_str()) {
-                                    Ok(acp::SessionId::new(sid))
-                                } else {
-                                    Err(crate::Error::Provider(
-                                        "Gemini session/new response missing sessionId".into(),
-                                    ))
-                                }
-                            }
-                            Err(e) => {
-                                tracing::debug!("Gemini session/new failed: {e}");
-                                Err(e)
-                            }
-                        }
-                    }
-                    None => Err(crate::Error::Provider(
-                        "ACP client not connected".to_string(),
-                    )),
+                    Err(e) => Err(e),
                 };
                 let _ = reply.send(result);
             }
-
             AcpCommand::Prompt {
                 session_id,
                 message,
                 reply,
             } => {
-                let result = match connection.as_ref() {
-                    Some(Connection::Standard(conn)) => {
-                        let prompt_result = standard_prompt_with_idle_timeout(
-                            conn,
-                            session_id.clone(),
-                            &message,
-                            &config.agent_type,
-                        )
-                        .await;
-                        match prompt_result {
-                            Ok(_) => {
-                                let text =
-                                    collector.borrow_mut().take_content(session_id.0.as_ref());
-                                Ok(text)
-                            }
-                            Err(e) => Err(e),
-                        }
-                    }
-                    Some(Connection::Gemini(conn)) => {
-                        tracing::debug!(
-                            "Gemini: calling session/prompt for session '{}'",
-                            session_id.0
-                        );
-                        let result = conn
-                            .call(
-                                "session/prompt",
-                                json!({
-                                    "sessionId": session_id.0,
-                                    "prompt": [{"type": "text", "text": message}]
-                                }),
-                            )
-                            .await;
-
-                        match result {
-                            Ok(_) => {
-                                tracing::debug!(
-                                    "Gemini session/prompt completed for session '{}'",
-                                    session_id.0
-                                );
-                                let text =
-                                    collector.borrow_mut().take_content(session_id.0.as_ref());
-                                Ok(text)
-                            }
-                            Err(ref e) => {
-                                tracing::debug!(
-                                    "Gemini session/prompt failed for session '{}': {e}",
-                                    session_id.0
-                                );
-                                result.map(|_| String::new())
-                            }
-                        }
-                    }
-                    None => Err(crate::Error::Provider(
-                        "ACP client not connected".to_string(),
-                    )),
+                let result = match standard_prompt(
+                    &connection,
+                    &session_id,
+                    &message,
+                    activity,
+                    diagnostics,
+                    &config.agent_type,
+                )
+                .await
+                {
+                    Ok(()) => Ok(lock_collector(collector).take_content(session_id.0.as_ref())),
+                    Err(e) => Err(e),
                 };
                 let _ = reply.send(result);
             }
-
-            AcpCommand::Cancel { session_id } => match connection.as_ref() {
-                Some(Connection::Standard(conn)) => {
-                    let _ = conn
-                        .conn
-                        .cancel(acp::CancelNotification::new(session_id))
-                        .await;
-                }
-                Some(Connection::Gemini(conn)) => {
-                    let _ = conn
-                        .call("session/cancel", json!({ "sessionId": session_id.0 }))
-                        .await;
-                }
-                None => {}
-            },
-
-            AcpCommand::Shutdown => {
-                if let Some(ref mut c) = child {
-                    let _ = c.kill().await;
-                }
-                break;
+            AcpCommand::Cancel { session_id } => {
+                let _ = connection.send_notification(CancelNotification::new(session_id));
             }
+            AcpCommand::Shutdown => break,
         }
     }
 }
 
 fn attach_http_mcp_server(
-    mut request: acp::NewSessionRequest,
+    mut request: NewSessionRequest,
     mcp_server_url: Option<String>,
     bearer_token: Option<String>,
-    mcp_capabilities: &acp::McpCapabilities,
+    mcp_capabilities: &McpCapabilities,
     provider_name: &str,
-) -> Result<acp::NewSessionRequest> {
+) -> Result<NewSessionRequest> {
     let Some(url) = mcp_server_url else {
         return Ok(request);
     };
@@ -621,30 +762,36 @@ fn attach_http_mcp_server(
     }
 
     tracing::debug!("Attaching MCP server at {}", url);
-    let mut mcp_http = acp::McpServerHttp::new("feroxmute", url);
+    let mut mcp_http = McpServerHttp::new("feroxmute", url);
     if let Some(token) = bearer_token {
-        mcp_http = mcp_http.headers(vec![acp::HttpHeader::new(
+        mcp_http = mcp_http.headers(vec![HttpHeader::new(
             "Authorization",
             format!("Bearer {token}"),
         )]);
     }
-    request = request.mcp_servers(vec![acp::McpServer::Http(mcp_http)]);
+    request = request.mcp_servers(vec![McpServer::Http(mcp_http)]);
 
     Ok(request)
 }
 
-async fn standard_new_session_with_timeout(
-    conn: &StandardConnection,
-    request: acp::NewSessionRequest,
+async fn standard_new_session(
+    connection: &ConnectionTo<Agent>,
+    request: NewSessionRequest,
     provider_name: &str,
-) -> Result<acp::SessionId> {
-    match tokio::time::timeout(ACP_SETUP_TIMEOUT, conn.conn.new_session(request)).await {
+    diagnostics: &Rc<RefCell<CliDiagnostics>>,
+) -> Result<SessionId> {
+    match tokio::time::timeout(
+        ACP_SETUP_TIMEOUT,
+        connection.send_request(request).block_task(),
+    )
+    .await
+    {
         Ok(Ok(response)) => Ok(response.session_id),
         Ok(Err(e)) => Err(crate::Error::Provider(format!(
             "Failed to create ACP session: {e}"
         ))),
         Err(_) => {
-            let diagnostics = conn.diagnostics.borrow().recent_summary();
+            let diagnostics = diagnostics.borrow().recent_summary();
             Err(crate::Error::Provider(format!(
                 "{provider_name} ACP session/new timed out after {} seconds. \
                  The CLI connected, but did not create a session with feroxmute's MCP server. \
@@ -656,16 +803,20 @@ async fn standard_new_session_with_timeout(
     }
 }
 
-async fn standard_prompt_with_idle_timeout(
-    conn: &StandardConnection,
-    session_id: acp::SessionId,
+async fn standard_prompt(
+    connection: &ConnectionTo<Agent>,
+    session_id: &SessionId,
     message: &str,
+    activity: &Arc<Notify>,
+    diagnostics: &Rc<RefCell<CliDiagnostics>>,
     agent_type: &CliAgentType,
-) -> Result<acp::PromptResponse> {
-    let prompt_result = conn.conn.prompt(acp::PromptRequest::new(
-        session_id.clone(),
-        vec![acp::ContentBlock::Text(acp::TextContent::new(message))],
-    ));
+) -> Result<()> {
+    let prompt_result = connection
+        .send_request(PromptRequest::new(
+            session_id.clone(),
+            vec![ContentBlock::Text(TextContent::new(message))],
+        ))
+        .block_task();
     tokio::pin!(prompt_result);
 
     let idle_deadline = tokio::time::Instant::now() + ACP_PROMPT_IDLE_TIMEOUT;
@@ -675,11 +826,11 @@ async fn standard_prompt_with_idle_timeout(
     loop {
         tokio::select! {
             result = &mut prompt_result => {
-                return result.map_err(|e| standard_prompt_error(&e, agent_type));
+                return result.map(|_| ()).map_err(|e| standard_prompt_error(&e, agent_type));
             }
             _ = &mut idle_sleep => {
-                let _ = conn.conn.cancel(acp::CancelNotification::new(session_id.clone())).await;
-                let diagnostics = conn.diagnostics.borrow().recent_summary();
+                let _ = connection.send_notification(CancelNotification::new(session_id.clone()));
+                let diagnostics = diagnostics.borrow().recent_summary();
                 return Err(crate::Error::Provider(format!(
                     "{} ACP prompt timed out after {} seconds of inactivity. \
                      The CLI connected, but did not return a response or emit ACP activity. \
@@ -689,7 +840,7 @@ async fn standard_prompt_with_idle_timeout(
                     diagnostics,
                 )));
             }
-            _ = conn.activity.notified() => {
+            _ = activity.notified() => {
                 idle_sleep
                     .as_mut()
                     .reset(tokio::time::Instant::now() + ACP_PROMPT_IDLE_TIMEOUT);
@@ -710,6 +861,298 @@ fn standard_prompt_error(e: &acp::Error, agent_type: &CliAgentType) -> crate::Er
     }
 }
 
+/// Pick the best permission option from the agent's list.
+///
+/// feroxmute handles its own permissions via the MCP tool layer, so all tool
+/// calls are auto-approved: prefer `AllowAlways`, then `AllowOnce`, then first.
+fn pick_permission_option(request: &RequestPermissionRequest) -> String {
+    request
+        .options
+        .iter()
+        .find(|o| o.kind == PermissionOptionKind::AllowAlways)
+        .or_else(|| {
+            request
+                .options
+                .iter()
+                .find(|o| o.kind == PermissionOptionKind::AllowOnce)
+        })
+        .or_else(|| request.options.first())
+        .map(|o| o.option_id.0.to_string())
+        .unwrap_or_else(|| "allow_always".to_string())
+}
+
+/// Handle a session notification from the Standard ACP connection.
+fn handle_standard_notification(collector: &SharedCollector, notification: SessionNotification) {
+    let session_id = notification.session_id.0.to_string();
+
+    match notification.update {
+        SessionUpdate::AgentMessageChunk(chunk) => {
+            if let ContentBlock::Text(text_content) = chunk.content {
+                lock_collector(collector).add_content(&session_id, text_content.text);
+            }
+        }
+        SessionUpdate::AgentThoughtChunk(_) => {
+            tracing::trace!("ACP thought chunk for session '{session_id}'");
+        }
+        SessionUpdate::ToolCall(tool_call) => {
+            tracing::debug!(
+                "ACP tool call for session '{}': {} ({})",
+                session_id,
+                tool_call.title,
+                tool_call.tool_call_id.0
+            );
+        }
+        SessionUpdate::ToolCallUpdate(update) => {
+            if let Some(ToolCallStatus::Completed) = update.fields.status {
+                tracing::debug!(
+                    "ACP tool call completed for session '{}': {}",
+                    session_id,
+                    update.tool_call_id.0
+                );
+            }
+        }
+        _ => {
+            tracing::trace!("ACP session notification: {:?}", notification.update);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gemini ACP path (manual JSON-RPC)
+// ---------------------------------------------------------------------------
+
+/// Establish a Gemini CLI connection over manual JSON-RPC and initialize it.
+async fn connect_gemini(
+    child_io: ChildIo,
+    collector: &SharedCollector,
+) -> Result<(Child, GeminiConnection)> {
+    let ChildIo {
+        child,
+        stdin,
+        stdout,
+        diagnostics: _,
+    } = child_io;
+
+    let stdin = Arc::new(Mutex::new(stdin.compat_write()));
+    let pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Value>>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    let pending_requests_clone = Arc::clone(&pending_requests);
+    let collector_clone = Arc::clone(collector);
+    let activity = Arc::new(Notify::new());
+    let activity_clone = Arc::clone(&activity);
+
+    let stdin_clone = Arc::clone(&stdin);
+    tokio::task::spawn_local(async move {
+        let mut reader = BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = reader.next_line().await {
+            tracing::debug!("Gemini stdout: {}", line);
+            let val: Value = match serde_json::from_str(&line) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!("Gemini stdout non-JSON: {e}");
+                    continue;
+                }
+            };
+
+            // Distinguish responses (result/error) from requests/notifications (method).
+            // A JSON-RPC response has `result` or `error`; a request has `method`.
+            let is_response = val.get("result").is_some() || val.get("error").is_some();
+            let has_method = val.get("method").is_some();
+
+            if is_response && !has_method {
+                // Response to one of our pending requests
+                if let Some(id) = val.get("id").and_then(|v| v.as_u64())
+                    && let Some(tx) = pending_requests_clone.lock().await.remove(&id)
+                {
+                    tracing::debug!("Gemini response matched pending request #{id}");
+                    if let Some(error) = val.get("error") {
+                        let _ = tx.send(Err(crate::Error::Provider(format!(
+                            "Gemini ACP error: {error}"
+                        ))));
+                    } else {
+                        let _ = tx.send(Ok(val.get("result").cloned().unwrap_or(Value::Null)));
+                    }
+                } else {
+                    tracing::warn!("Gemini response for unknown id: {}", val);
+                }
+            } else if let Some(method) = val.get("method").and_then(|v| v.as_str()) {
+                let has_id = val.get("id").is_some();
+
+                // Signal activity so idle timeout resets.
+                activity_clone.notify_waiters();
+
+                if has_id {
+                    // Agent-initiated request — needs a response sent back
+                    tracing::debug!("Gemini agent request: {method} body={val}");
+                    handle_gemini_request(method, &val, &stdin_clone).await;
+                } else {
+                    // Notification — no response needed
+                    tracing::debug!("Gemini notification: {method}");
+                    handle_gemini_notification(method, &val, &collector_clone);
+                }
+            } else {
+                tracing::warn!("Gemini stdout unrecognized message: {}", val);
+            }
+        }
+        // Resolve all pending requests with an error so call() doesn't hang
+        let mut pending = pending_requests_clone.lock().await;
+        let pending_count = pending.len();
+        if pending_count > 0 {
+            tracing::warn!("Gemini stdout reader exited with {pending_count} pending request(s)");
+        } else {
+            tracing::debug!("Gemini stdout reader exited cleanly");
+        }
+        for (id, tx) in pending.drain() {
+            let _ = tx.send(Err(crate::Error::Provider(format!(
+                "Gemini CLI process exited while request #{id} was pending"
+            ))));
+        }
+    });
+
+    let gemini_conn = GeminiConnection {
+        stdin,
+        pending_requests,
+        next_id: AtomicU64::new(1),
+        activity,
+    };
+
+    // Initialize Gemini connection
+    gemini_conn
+        .call(
+            "initialize",
+            json!({
+                "protocolVersion": 1,
+                "clientInfo": {
+                    "name": "feroxmute",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }),
+        )
+        .await?;
+
+    Ok((child, gemini_conn))
+}
+
+/// Per-session command loop for the Gemini CLI connection.
+async fn gemini_command_loop(
+    cmd_rx: &mut mpsc::Receiver<AcpCommand>,
+    mut child: Child,
+    conn: GeminiConnection,
+    collector: &SharedCollector,
+) {
+    while let Some(cmd) = cmd_rx.recv().await {
+        match cmd {
+            AcpCommand::Connect { reply, .. } => {
+                let _ = reply.send(Ok(()));
+            }
+            AcpCommand::NewSession {
+                agent_role,
+                working_dir,
+                mcp_server_url,
+                bearer_token,
+                reply,
+            } => {
+                tracing::debug!("Creating Gemini ACP session for role '{agent_role}'");
+                let mut mcp_servers = Vec::new();
+                if let Some(url) = mcp_server_url {
+                    let mut headers = vec![];
+                    if let Some(ref token) = bearer_token {
+                        headers.push(json!({
+                            "name": "Authorization",
+                            "value": format!("Bearer {token}")
+                        }));
+                    }
+                    mcp_servers.push(json!({
+                        "name": "feroxmute",
+                        "type": "http",
+                        "url": url,
+                        "headers": headers
+                    }));
+                }
+
+                tracing::debug!(
+                    "Gemini: calling session/new with {} MCP server(s)",
+                    mcp_servers.len()
+                );
+                let result = conn
+                    .call(
+                        "session/new",
+                        json!({
+                            "cwd": working_dir.to_string_lossy(),
+                            "mcpServers": mcp_servers
+                        }),
+                    )
+                    .await;
+
+                let result = match result {
+                    Ok(res) => {
+                        tracing::debug!("Gemini session/new returned: {res}");
+                        if let Some(sid) = res.get("sessionId").and_then(|v| v.as_str()) {
+                            Ok(SessionId::new(sid))
+                        } else {
+                            Err(crate::Error::Provider(
+                                "Gemini session/new response missing sessionId".into(),
+                            ))
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!("Gemini session/new failed: {e}");
+                        Err(e)
+                    }
+                };
+                let _ = reply.send(result);
+            }
+            AcpCommand::Prompt {
+                session_id,
+                message,
+                reply,
+            } => {
+                tracing::debug!(
+                    "Gemini: calling session/prompt for session '{}'",
+                    session_id.0
+                );
+                let result = conn
+                    .call(
+                        "session/prompt",
+                        json!({
+                            "sessionId": session_id.0,
+                            "prompt": [{"type": "text", "text": message}]
+                        }),
+                    )
+                    .await;
+
+                let result = match result {
+                    Ok(_) => {
+                        tracing::debug!(
+                            "Gemini session/prompt completed for session '{}'",
+                            session_id.0
+                        );
+                        Ok(lock_collector(collector).take_content(session_id.0.as_ref()))
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            "Gemini session/prompt failed for session '{}': {e}",
+                            session_id.0
+                        );
+                        Err(e)
+                    }
+                };
+                let _ = reply.send(result);
+            }
+            AcpCommand::Cancel { session_id } => {
+                let _ = conn
+                    .call("session/cancel", json!({ "sessionId": session_id.0 }))
+                    .await;
+            }
+            AcpCommand::Shutdown => {
+                let _ = child.kill().await;
+                return;
+            }
+        }
+    }
+    let _ = child.kill().await;
+}
+
 /// Handle an agent-initiated JSON-RPC request from Gemini CLI.
 ///
 /// The agent may send requests like `request_permission` when it needs approval
@@ -724,7 +1167,7 @@ async fn handle_gemini_request(
     let response = match method {
         "request_permission" | "session/request_permission" => {
             // Auto-approve all tool calls — feroxmute handles its own permissions
-            // via the MCP tool layer. Mirrors the Standard delegate's behavior.
+            // via the MCP tool layer. Mirrors the Standard path's behavior.
             //
             // ACP options use `optionId` for the ID and `kind` for the type
             // (allow_always, allow_once, reject_once, etc.). Gemini CLI sends
@@ -794,11 +1237,7 @@ async fn handle_gemini_request(
 ///    ```json
 ///    {"agentMessageChunk": {"content": {"text": "..."}}}
 ///    ```
-fn handle_gemini_notification(
-    method: &str,
-    val: &Value,
-    collector: &Rc<RefCell<ResponseCollector>>,
-) {
+fn handle_gemini_notification(method: &str, val: &Value, collector: &SharedCollector) {
     if method != "session/update" && method != "session/notification" {
         tracing::trace!("Gemini notification: {method}");
         return;
@@ -825,9 +1264,7 @@ fn handle_gemini_notification(
         // ACP spec tagged format: content fields are inline in `update`
         "agent_message_chunk" => {
             if let Some(text_str) = extract_content_text(update) {
-                collector
-                    .borrow_mut()
-                    .add_content(session_id, text_str.to_string());
+                lock_collector(collector).add_content(session_id, text_str.to_string());
             }
         }
         "agent_thought_chunk" => {
@@ -843,9 +1280,7 @@ fn handle_gemini_notification(
             // Try nested object format (fallback)
             if let Some(msg) = update.get("agentMessageChunk") {
                 if let Some(text_str) = extract_content_text(msg) {
-                    collector
-                        .borrow_mut()
-                        .add_content(session_id, text_str.to_string());
+                    lock_collector(collector).add_content(session_id, text_str.to_string());
                 }
             } else if let Some(thought) = update.get("agentThoughtChunk") {
                 tracing::trace!("Gemini thought chunk for session '{session_id}': {thought}");
@@ -867,273 +1302,9 @@ fn extract_content_text(obj: &Value) -> Option<&str> {
         .and_then(|t| t.as_str())
 }
 
-fn summarize_acp_stream_message(message: &acp::StreamMessage) -> String {
-    let direction = match message.direction {
-        acp::StreamMessageDirection::Incoming => "<-",
-        acp::StreamMessageDirection::Outgoing => "->",
-    };
-
-    match &message.message {
-        acp::StreamMessageContent::Request { id, method, .. } => {
-            format!("{direction} request {id:?} {method}")
-        }
-        acp::StreamMessageContent::Response { id, result } => match result {
-            Ok(_) => format!("{direction} response {id:?} ok"),
-            Err(e) => format!("{direction} response {id:?} error {e}"),
-        },
-        acp::StreamMessageContent::Notification { method, .. } => {
-            format!("{direction} notification {method}")
-        }
-    }
-}
-
-/// Spawn the CLI subprocess and establish the ACP connection.
-///
-/// For CLI agents that use ACP adapters (e.g. `claude-code-acp`), the binary
-/// speaks ACP natively over stdin/stdout. MCP servers are provided later via
-/// `NewSessionRequest.mcp_servers` rather than CLI flags.
-async fn do_connect(
-    config: &CliAgentConfig,
-    working_dir: &Path,
-    collector: &Rc<RefCell<ResponseCollector>>,
-) -> Result<(Child, Connection)> {
-    // Check binary availability first
-    if which::which(&config.binary_path).is_err() {
-        return Err(crate::Error::Provider(format!(
-            "{} CLI not found at '{}'. Install it or specify path with --cli-path. Auth hint: {}",
-            config.agent_type.provider_name(),
-            config.binary_path.display(),
-            config.agent_type.auth_hint()
-        )));
-    }
-
-    let mut cmd = Command::new(&config.binary_path);
-    cmd.current_dir(working_dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-
-    match config.agent_type {
-        CliAgentType::Codex => {
-            cmd.arg("-c")
-                .arg(format!("model={}", toml_string_literal(&config.model)));
-        }
-        CliAgentType::GeminiCli => {
-            cmd.arg("--experimental-acp");
-            cmd.arg("-m").arg(&config.model);
-        }
-        CliAgentType::ClaudeCode => {}
-    }
-
-    let mut child = cmd.spawn().map_err(|e| {
-        crate::Error::Provider(format!(
-            "Failed to spawn {} CLI: {e}",
-            config.agent_type.provider_name(),
-        ))
-    })?;
-
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| crate::Error::Provider("Failed to capture CLI stdin".to_string()))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| crate::Error::Provider("Failed to capture CLI stdout".to_string()))?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| crate::Error::Provider("Failed to capture CLI stderr".to_string()))?;
-
-    let diagnostics = Rc::new(RefCell::new(CliDiagnostics::default()));
-    let diagnostics_for_stderr = Rc::clone(&diagnostics);
-
-    // Log stderr in a background task
-    tokio::task::spawn_local(async move {
-        use tokio::io::AsyncBufReadExt;
-        let mut reader = tokio::io::BufReader::new(stderr).lines();
-        while let Ok(Some(line)) = reader.next_line().await {
-            diagnostics_for_stderr
-                .borrow_mut()
-                .push_stderr(line.clone());
-            tracing::warn!("CLI STDERR: {}", line);
-        }
-    });
-
-    if config.agent_type == CliAgentType::GeminiCli {
-        let stdin = Arc::new(Mutex::new(stdin.compat_write()));
-        let pending_requests: Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Value>>>>> =
-            Arc::new(Mutex::new(HashMap::new()));
-        let pending_requests_clone = Arc::clone(&pending_requests);
-        let collector_clone = Rc::clone(collector);
-        let activity = Arc::new(Notify::new());
-        let activity_clone = Arc::clone(&activity);
-
-        let stdin_clone = Arc::clone(&stdin);
-        tokio::task::spawn_local(async move {
-            let mut reader = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
-                tracing::debug!("Gemini stdout: {}", line);
-                let val: Value = match serde_json::from_str(&line) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        tracing::warn!("Gemini stdout non-JSON: {e}");
-                        continue;
-                    }
-                };
-
-                // Distinguish responses (result/error) from requests/notifications (method).
-                // A JSON-RPC response has `result` or `error`; a request has `method`.
-                let is_response = val.get("result").is_some() || val.get("error").is_some();
-                let has_method = val.get("method").is_some();
-
-                if is_response && !has_method {
-                    // Response to one of our pending requests
-                    if let Some(id) = val.get("id").and_then(|v| v.as_u64())
-                        && let Some(tx) = pending_requests_clone.lock().await.remove(&id)
-                    {
-                        tracing::debug!("Gemini response matched pending request #{id}");
-                        if let Some(error) = val.get("error") {
-                            let _ = tx.send(Err(crate::Error::Provider(format!(
-                                "Gemini ACP error: {}",
-                                error
-                            ))));
-                        } else {
-                            let _ = tx.send(Ok(val.get("result").cloned().unwrap_or(Value::Null)));
-                        }
-                    } else {
-                        tracing::warn!("Gemini response for unknown id: {}", val);
-                    }
-                } else if let Some(method) = val.get("method").and_then(|v| v.as_str()) {
-                    let has_id = val.get("id").is_some();
-
-                    // Signal activity so idle timeout resets.
-                    activity_clone.notify_waiters();
-
-                    if has_id {
-                        // Agent-initiated request — needs a response sent back
-                        tracing::debug!("Gemini agent request: {method} body={val}");
-                        handle_gemini_request(method, &val, &stdin_clone).await;
-                    } else {
-                        // Notification — no response needed
-                        tracing::debug!("Gemini notification: {method}");
-                        handle_gemini_notification(method, &val, &collector_clone);
-                    }
-                } else {
-                    tracing::warn!("Gemini stdout unrecognized message: {}", val);
-                }
-            }
-            // Resolve all pending requests with an error so call() doesn't hang
-            let mut pending = pending_requests_clone.lock().await;
-            let pending_count = pending.len();
-            if pending_count > 0 {
-                tracing::warn!(
-                    "Gemini stdout reader exited with {pending_count} pending request(s)"
-                );
-            } else {
-                tracing::debug!("Gemini stdout reader exited cleanly");
-            }
-            for (id, tx) in pending.drain() {
-                let _ = tx.send(Err(crate::Error::Provider(format!(
-                    "Gemini CLI process exited while request #{id} was pending"
-                ))));
-            }
-        });
-
-        let gemini_conn = GeminiConnection {
-            stdin,
-            pending_requests,
-            next_id: AtomicU64::new(1),
-            activity,
-        };
-
-        // Initialize Gemini connection
-        gemini_conn
-            .call(
-                "initialize",
-                json!({
-                    "protocolVersion": 1,
-                    "clientInfo": {
-                        "name": "feroxmute",
-                        "version": env!("CARGO_PKG_VERSION")
-                    }
-                }),
-            )
-            .await?;
-
-        Ok((child, Connection::Gemini(gemini_conn)))
-    } else {
-        let activity = Rc::new(Notify::new());
-
-        // Build delegate (Rc-based, single-threaded)
-        let delegate = AcpClientDelegate {
-            collector: Rc::clone(collector),
-            activity: Rc::clone(&activity),
-        };
-
-        let (conn, io_task) = acp::ClientSideConnection::new(
-            delegate,
-            stdin.compat_write(),
-            stdout.compat(),
-            |fut| {
-                tokio::task::spawn_local(fut);
-            },
-        );
-
-        let mut stream = conn.subscribe();
-        let activity_for_stream = Rc::clone(&activity);
-        let diagnostics_for_stream = Rc::clone(&diagnostics);
-        tokio::task::spawn_local(async move {
-            while let Ok(message) = stream.recv().await {
-                if matches!(message.direction, acp::StreamMessageDirection::Incoming) {
-                    activity_for_stream.notify_waiters();
-                }
-                let summary = summarize_acp_stream_message(&message);
-                diagnostics_for_stream
-                    .borrow_mut()
-                    .push_rpc_event(summary.clone());
-                tracing::debug!("ACP RPC: {summary}");
-            }
-        });
-
-        // Spawn IO task on the LocalSet
-        tokio::task::spawn_local(async move {
-            if let Err(e) = io_task.await {
-                tracing::error!("ACP IO task error: {e}");
-            }
-        });
-
-        // Initialize the connection
-        let init_response = conn
-            .initialize(
-                acp::InitializeRequest::new(acp::ProtocolVersion::V1).client_info(
-                    acp::Implementation::new("feroxmute", env!("CARGO_PKG_VERSION")),
-                ),
-            )
-            .await
-            .map_err(|e| crate::Error::Provider(format!("ACP initialization failed: {e}")))?;
-
-        let mcp_capabilities = init_response.agent_capabilities.mcp_capabilities.clone();
-
-        tracing::info!(
-            "Connected to {} (protocol version: {:?}, mcp_http: {}, mcp_sse: {})",
-            config.agent_type.provider_name(),
-            init_response.protocol_version,
-            mcp_capabilities.http,
-            mcp_capabilities.sse
-        );
-
-        Ok((
-            child,
-            Connection::Standard(StandardConnection {
-                conn,
-                activity,
-                diagnostics,
-                mcp_capabilities,
-            }),
-        ))
-    }
-}
+// ---------------------------------------------------------------------------
+// Codex model TOML quoting
+// ---------------------------------------------------------------------------
 
 fn toml_string_literal(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len() + 2);
@@ -1179,90 +1350,6 @@ fn push_toml_unicode_escape(output: &mut String, ch: char) {
             15 => 'F',
             _ => '0',
         });
-    }
-}
-
-// ---------------------------------------------------------------------------
-// ACP Client delegate (lives inside bridge thread, !Send is fine)
-// ---------------------------------------------------------------------------
-
-struct AcpClientDelegate {
-    collector: Rc<RefCell<ResponseCollector>>,
-    activity: Rc<Notify>,
-}
-
-#[async_trait::async_trait(?Send)]
-impl acp::Client for AcpClientDelegate {
-    async fn request_permission(
-        &self,
-        args: acp::RequestPermissionRequest,
-    ) -> acp::Result<acp::RequestPermissionResponse> {
-        self.activity.notify_waiters();
-
-        // Auto-approve all tool calls — feroxmute handles its own permissions
-        // via the MCP tool layer. Pick the best option from the agent's list:
-        // prefer AllowAlways > AllowOnce > first available.
-        let option_id = args
-            .options
-            .iter()
-            .find(|o| o.kind == acp::PermissionOptionKind::AllowAlways)
-            .or_else(|| {
-                args.options
-                    .iter()
-                    .find(|o| o.kind == acp::PermissionOptionKind::AllowOnce)
-            })
-            .or_else(|| args.options.first())
-            .map(|o| o.option_id.0.to_string())
-            .unwrap_or_else(|| "allow_always".to_string());
-
-        tracing::debug!("ACP request_permission auto-approved with '{option_id}'");
-        Ok(acp::RequestPermissionResponse::new(
-            acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(option_id)),
-        ))
-    }
-
-    async fn session_notification(
-        &self,
-        notification: acp::SessionNotification,
-    ) -> acp::Result<()> {
-        self.activity.notify_waiters();
-
-        let session_id = notification.session_id.0.to_string();
-
-        match notification.update {
-            acp::SessionUpdate::AgentMessageChunk(chunk) => {
-                if let acp::ContentBlock::Text(text_content) = chunk.content {
-                    self.collector
-                        .borrow_mut()
-                        .add_content(&session_id, text_content.text);
-                }
-            }
-            acp::SessionUpdate::AgentThoughtChunk(_) => {
-                tracing::trace!("ACP thought chunk for session '{session_id}'");
-            }
-            acp::SessionUpdate::ToolCall(tool_call) => {
-                tracing::debug!(
-                    "ACP tool call for session '{}': {} ({})",
-                    session_id,
-                    tool_call.title,
-                    tool_call.tool_call_id.0
-                );
-            }
-            acp::SessionUpdate::ToolCallUpdate(update) => {
-                if let Some(acp::ToolCallStatus::Completed) = update.fields.status {
-                    tracing::debug!(
-                        "ACP tool call completed for session '{}': {}",
-                        session_id,
-                        update.tool_call_id.0
-                    );
-                }
-            }
-            _ => {
-                tracing::trace!("ACP session notification: {:?}", notification.update);
-            }
-        }
-
-        Ok(())
     }
 }
 

--- a/feroxmute-core/src/providers/cli_agent/bridge.rs
+++ b/feroxmute-core/src/providers/cli_agent/bridge.rs
@@ -481,17 +481,19 @@ struct ChildIo {
 /// speaks ACP natively over stdin/stdout. MCP servers are provided later via
 /// `NewSessionRequest.mcp_servers` rather than CLI flags.
 fn prepare_child(config: &CliAgentConfig, working_dir: &Path) -> Result<ChildIo> {
-    // Check binary availability first
-    if which::which(&config.binary_path).is_err() {
-        return Err(crate::Error::Provider(format!(
+    // Resolve the binary to an absolute path. `current_dir` below would
+    // otherwise make a relative binary name resolve against `working_dir`
+    // instead of `PATH`.
+    let binary_path = which::which(&config.binary_path).map_err(|_| {
+        crate::Error::Provider(format!(
             "{} CLI not found at '{}'. Install it or specify path with --cli-path. Auth hint: {}",
             config.agent_type.provider_name(),
             config.binary_path.display(),
             config.agent_type.auth_hint()
-        )));
-    }
+        ))
+    })?;
 
-    let mut cmd = Command::new(&config.binary_path);
+    let mut cmd = Command::new(&binary_path);
     cmd.current_dir(working_dir)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/feroxmute-core/src/providers/cli_agent/bridge.rs
+++ b/feroxmute-core/src/providers/cli_agent/bridge.rs
@@ -477,7 +477,7 @@ struct ChildIo {
 
 /// Spawn the CLI subprocess and capture its stdio.
 ///
-/// For CLI agents that use ACP adapters (e.g. `cc-acp`), the binary
+/// For CLI agents that use ACP adapters (e.g. `claude-code-acp`), the binary
 /// speaks ACP natively over stdin/stdout. MCP servers are provided later via
 /// `NewSessionRequest.mcp_servers` rather than CLI flags.
 fn prepare_child(config: &CliAgentConfig, working_dir: &Path) -> Result<ChildIo> {

--- a/feroxmute-core/src/providers/cli_agent/bridge.rs
+++ b/feroxmute-core/src/providers/cli_agent/bridge.rs
@@ -477,7 +477,7 @@ struct ChildIo {
 
 /// Spawn the CLI subprocess and capture its stdio.
 ///
-/// For CLI agents that use ACP adapters (e.g. `claude-code-acp`), the binary
+/// For CLI agents that use ACP adapters (e.g. `cc-acp`), the binary
 /// speaks ACP natively over stdin/stdout. MCP servers are provided later via
 /// `NewSessionRequest.mcp_servers` rather than CLI flags.
 fn prepare_child(config: &CliAgentConfig, working_dir: &Path) -> Result<ChildIo> {

--- a/feroxmute-core/src/providers/cli_agent/config.rs
+++ b/feroxmute-core/src/providers/cli_agent/config.rs
@@ -24,12 +24,13 @@ impl CliAgentType {
 
     /// Get the default binary name
     ///
-    /// Note: Codex does not speak ACP natively — the `codex-acp` adapter
-    /// binary (maintained by Zed Industries) translates between ACP and
-    /// Codex's internal protocol.
+    /// Note: neither Claude Code nor Codex speak ACP natively. The
+    /// `claude-code-acp` npm package ships its adapter as the `cc-acp`
+    /// binary, and the `codex-acp` adapter (both maintained by Zed
+    /// Industries) translates between ACP and the agent's internal protocol.
     pub fn default_binary(&self) -> &'static str {
         match self {
-            Self::ClaudeCode => "claude-code-acp",
+            Self::ClaudeCode => "cc-acp",
             Self::Codex => "codex-acp",
             Self::GeminiCli => "gemini",
         }

--- a/feroxmute-core/src/providers/cli_agent/config.rs
+++ b/feroxmute-core/src/providers/cli_agent/config.rs
@@ -24,13 +24,14 @@ impl CliAgentType {
 
     /// Get the default binary name
     ///
-    /// Note: neither Claude Code nor Codex speak ACP natively. The
-    /// `claude-code-acp` npm package ships its adapter as the `cc-acp`
-    /// binary, and the `codex-acp` adapter (both maintained by Zed
-    /// Industries) translates between ACP and the agent's internal protocol.
+    /// Note: neither Claude Code nor Codex speak ACP natively. Zed Industries
+    /// maintains adapters that translate between ACP and each agent's internal
+    /// protocol: `@zed-industries/claude-code-acp` (binary `claude-code-acp`)
+    /// and `@zed-industries/codex-acp` (binary `codex-acp`). Both advertise
+    /// HTTP MCP support, so feroxmute attaches its tool server over HTTP.
     pub fn default_binary(&self) -> &'static str {
         match self {
-            Self::ClaudeCode => "cc-acp",
+            Self::ClaudeCode => "claude-code-acp",
             Self::Codex => "codex-acp",
             Self::GeminiCli => "gemini",
         }

--- a/feroxmute-core/src/providers/cli_agent/provider.rs
+++ b/feroxmute-core/src/providers/cli_agent/provider.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use agent_client_protocol as acp;
+use agent_client_protocol::schema::v1::SessionId;
 use async_trait::async_trait;
 use chrono::Utc;
 use tokio::sync::Mutex;
@@ -73,7 +73,7 @@ fn with_http_mcp_diagnostics(error: crate::Error, http: &HttpMcpServer) -> crate
 
 async fn prompt_with_progress(
     bridge: &AcpBridge,
-    session_id: &acp::SessionId,
+    session_id: &SessionId,
     prompt: &str,
     events: &dyn EventSender,
     agent_name: &str,

--- a/feroxmute-core/tests/cli_agent_provider.rs
+++ b/feroxmute-core/tests/cli_agent_provider.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 fn test_cli_agent_config_defaults() {
     let config = CliAgentConfig::new(CliAgentType::ClaudeCode);
     assert_eq!(config.model, "claude-opus-4.5");
-    assert_eq!(config.binary_path, PathBuf::from("claude-code-acp"));
+    assert_eq!(config.binary_path, PathBuf::from("cc-acp"));
 
     let config = CliAgentConfig::new(CliAgentType::Codex);
     assert_eq!(config.model, "gpt-5.2");
@@ -33,7 +33,7 @@ fn test_cli_agent_config_custom_model() {
     let config = CliAgentConfig::new(CliAgentType::ClaudeCode).with_model("claude-sonnet-4");
 
     assert_eq!(config.model, "claude-sonnet-4");
-    assert_eq!(config.binary_path, PathBuf::from("claude-code-acp"));
+    assert_eq!(config.binary_path, PathBuf::from("cc-acp"));
 }
 
 #[test]

--- a/feroxmute-core/tests/cli_agent_provider.rs
+++ b/feroxmute-core/tests/cli_agent_provider.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 fn test_cli_agent_config_defaults() {
     let config = CliAgentConfig::new(CliAgentType::ClaudeCode);
     assert_eq!(config.model, "claude-opus-4.5");
-    assert_eq!(config.binary_path, PathBuf::from("cc-acp"));
+    assert_eq!(config.binary_path, PathBuf::from("claude-code-acp"));
 
     let config = CliAgentConfig::new(CliAgentType::Codex);
     assert_eq!(config.model, "gpt-5.2");
@@ -33,7 +33,7 @@ fn test_cli_agent_config_custom_model() {
     let config = CliAgentConfig::new(CliAgentType::ClaudeCode).with_model("claude-sonnet-4");
 
     assert_eq!(config.model, "claude-sonnet-4");
-    assert_eq!(config.binary_path, PathBuf::from("cc-acp"));
+    assert_eq!(config.binary_path, PathBuf::from("claude-code-acp"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Update 170+ crates to latest semver-compatible versions (clap 4.6, hyper 1.10, chrono 0.4.45, bollard 0.20.2, …)
- Major bumps: `strum` 0.27 → 0.28 (no code change), `agent-client-protocol` 0.9.4 → **1.0.0**

## ACP 1.0 migration
The connection API was fully redesigned — `ClientSideConnection` (held long-lived in a struct) is gone, replaced by a `connect_with(transport, main_fn)` model where the connection only lives inside the closure. The CLI-agent bridge was rewritten:

- Standard-path command loop now runs **inside** `connect_with`'s `main_fn`
- Transport via `ByteStreams` over the child's stdin/stdout
- `send_request(...).block_task()` / `send_notification` replace `conn.new_session()/prompt()/cancel()`
- Permission/notification handling moved from an `impl acp::Client` delegate to `on_receive_request`/`on_receive_notification` builder callbacks; shared collector switched to `Arc<Mutex>` (callbacks require `Send`)
- Schema types repathed to `acp::schema::v1::*`
- Gemini manual JSON-RPC path preserved, split into `connect_gemini` + `gemini_command_loop`

## Verification
- `cargo build` ✓
- `cargo clippy --all-targets -- -D warnings` ✓ (no issues)
- `cargo test` ✓ — 432 passed, 2 ignored
- `cargo fmt` ✓

⚠️ Note: unit tests cover collector/parsing/connect-error paths. The live CLI-agent ACP flow (real `claude-code-acp`/Gemini binary) is not integration-tested in CI — worth a manual smoke test before merge.